### PR TITLE
Upgraded to Ruby 2.2.4; Fixed 2 links in README file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ pkg
 spec/reports
 tmp
 lib/photish/assets/output
+
+# Added these to not force others to use them.
+.overcommit.yml
+.rvmrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.2
+  - 2.2.4
 sudo: false
 before_install:
   - gem install bundler -v 1.10.6
@@ -12,3 +12,4 @@ addons:
     packages:
       - libmagic-dev
       - libimage-exiftool-perl
+cache: bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ rvm:
 sudo: false
 before_install:
   - gem install bundler -v 1.10.6
-script: rake
+script: bundle exec rake
 addons:
   code_climate:
     repo_token: ae398c193255da8c5e030cb6251f053c76757635e5215e65efa32f52d003a519

--- a/README.md
+++ b/README.md
@@ -721,6 +721,7 @@ To develop:
     $ git clone git@github.com:henrylawson/photish.git
     $ cd photish
     $ ./bin/setup     # installs dependencies
+    $ Install exiftool as detailed above.
     $ rake            # runs the tests
     $ vim             # open up the project and begin contributing
     $ ./bin/console   # for an interactive prompt
@@ -738,10 +739,10 @@ To release:
 Bug reports and pull requests are welcome on GitHub at
 https://github.com/henrylawson/photish. This project is intended to be a safe,
 welcoming space for collaboration, and contributors are expected to adhere to
-the [Contributor Covenant](contributor-covenant.org) code of conduct.
+the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 ## License
 
 The gem is available as open source under the terms of the [MIT
-License](http://opensource.org/licenses/MIT).
+License](https://opensource.org/licenses/MIT).
 


### PR DESCRIPTION
 * Upgraded to Ruby 2.2.4.
 * Fixed 2 links in README file
 * Added 1 line to set up instructions to remind about exiftool.
 * Added 3 lines to .gitignore file to not force others to use my conventions.